### PR TITLE
Add weighted graph algorithms for student demo

### DIFF
--- a/src/graph/City.java
+++ b/src/graph/City.java
@@ -1,0 +1,24 @@
+package graph; // Khai báo package chứa lớp City
+
+public class City { // Lớp City mô tả một thành phố trong bài toán
+    private final int id; // Mã số duy nhất cho mỗi thành phố
+    private final String name; // Tên hiển thị của thành phố
+
+    public City(int id, String name) { // Hàm tạo để gán mã số và tên cho thành phố
+        this.id = id; // Lưu mã số vào thuộc tính id
+        this.name = name; // Lưu tên vào thuộc tính name
+    }
+
+    public int getId() { // Trả về mã số của thành phố
+        return id; // Hoàn trả giá trị id đã lưu
+    }
+
+    public String getName() { // Trả về tên của thành phố
+        return name; // Hoàn trả giá trị name đã lưu
+    }
+
+    @Override
+    public String toString() { // Hiển thị thông tin thành phố dạng chuỗi
+        return name; // Chỉ trả về tên vì dễ đọc và ngắn gọn
+    }
+}

--- a/src/graph/GraphDemo.java
+++ b/src/graph/GraphDemo.java
@@ -1,0 +1,59 @@
+package graph; // Khai báo package cho lớp GraphDemo
+
+import java.util.List; // Sử dụng List để lưu kết quả duyệt và đường đi
+
+public class GraphDemo { // Lớp GraphDemo chứa hàm main minh họa cách dùng các lớp đã xây
+    public static void main(String[] args) { // Hàm main là điểm bắt đầu của chương trình Java
+        RoadGraph graph = new RoadGraph(); // Khởi tạo đồ thị đường đi có trọng số
+
+        City hanoi = graph.addCity("Ha Noi"); // Thêm thành phố Hà Nội vào đồ thị
+        City haiphong = graph.addCity("Hai Phong"); // Thêm thành phố Hải Phòng vào đồ thị
+        City danang = graph.addCity("Da Nang"); // Thêm thành phố Đà Nẵng vào đồ thị
+        City hcm = graph.addCity("Ho Chi Minh"); // Thêm thành phố Hồ Chí Minh vào đồ thị
+        City cantho = graph.addCity("Can Tho"); // Thêm thành phố Cần Thơ vào đồ thị
+
+        graph.addRoad(hanoi, haiphong, 120); // Nối Hà Nội với Hải Phòng bằng quãng đường 120 km
+        graph.addRoad(hanoi, danang, 780); // Nối Hà Nội với Đà Nẵng bằng quãng đường 780 km
+        graph.addRoad(haiphong, danang, 820); // Nối Hải Phòng với Đà Nẵng để tạo chu trình
+        graph.addRoad(danang, hcm, 960); // Nối Đà Nẵng với Hồ Chí Minh bằng quãng đường 960 km
+        graph.addRoad(hcm, cantho, 170); // Nối Hồ Chí Minh với Cần Thơ bằng quãng đường 170 km
+        graph.addRoad(haiphong, hcm, 1700); // Thêm đường dài giữa Hải Phòng và Hồ Chí Minh để tăng kết nối
+
+        System.out.println("Do thi lien thong: " + graph.isConnected()); // In ra trạng thái liên thông của đồ thị
+        System.out.println("Do thi co chu trinh: " + graph.hasCycle()); // In ra kết quả kiểm tra chu trình
+
+        List<City> bfsOrder = graph.breadthFirstTraversal(hanoi); // Thực hiện BFS từ Hà Nội
+        System.out.println("Thu tu BFS: " + bfsOrder); // In ra thứ tự duyệt BFS
+
+        List<City> dfsOrder = graph.depthFirstTraversal(hanoi); // Thực hiện DFS từ Hà Nội
+        System.out.println("Thu tu DFS: " + dfsOrder); // In ra thứ tự duyệt DFS
+
+        List<City> unweightedPath = graph.shortestPath(hanoi, cantho); // Tìm đường đi ngắn nhất theo BFS không trọng số
+        System.out.println("Duong di khong trong so: " + unweightedPath); // In đường đi không trọng số
+
+        List<City> weightedPath = graph.shortestPathDijkstra(hanoi, cantho); // Tìm đường đi ngắn nhất có trọng số bằng Dijkstra
+        System.out.println("Duong di Dijkstra: " + weightedPath); // In đường đi tìm được bằng Dijkstra
+
+        int[][] allPairs = graph.floydWarshall(); // Tính khoảng cách giữa mọi cặp thành phố bằng Floyd-Warshall
+        int inf = graph.getInfinityValue(); // Lấy giá trị vô cực để hiển thị đẹp
+        System.out.println("Ma tran Floyd-Warshall:"); // In tiêu đề cho ma trận
+        for (int i = 0; i < allPairs.length; i++) { // Duyệt từng dòng trong ma trận khoảng cách
+            for (int j = 0; j < allPairs[i].length; j++) { // Duyệt từng cột trong ma trận khoảng cách
+                int value = allPairs[i][j]; // Lấy giá trị khoảng cách hiện tại
+                if (value >= inf) { // Nếu giá trị bằng hoặc vượt vô cực
+                    System.out.print("INF\t"); // In chữ INF để dễ nhìn
+                } else { // Ngược lại là khoảng cách hữu hạn
+                    System.out.print(value + "\t"); // In ra số khoảng cách thực tế
+                }
+            }
+            System.out.println(); // Xuống dòng sau mỗi hàng của ma trận
+        }
+
+        int[] bellmanDistances = graph.bellmanFord(hanoi); // Tính khoảng cách từ Hà Nội đến các thành phố bằng Bellman-Ford
+        System.out.println("Khoang cach Bellman-Ford tu Ha Noi:"); // In tiêu đề cho danh sách khoảng cách
+        List<City> allCities = graph.getCities(); // Lấy danh sách thành phố để ghép với khoảng cách
+        for (int i = 0; i < allCities.size(); i++) { // Duyệt qua từng thành phố
+            System.out.println(allCities.get(i).getName() + ": " + bellmanDistances[i]); // In tên thành phố và khoảng cách tương ứng
+        }
+    }
+}

--- a/src/graph/GraphDemo.java
+++ b/src/graph/GraphDemo.java
@@ -21,6 +21,10 @@ public class GraphDemo { // Lớp GraphDemo chứa hàm main minh họa cách d�
 
         System.out.println("Do thi lien thong: " + graph.isConnected()); // In ra trạng thái liên thông của đồ thị
         System.out.println("Do thi co chu trinh: " + graph.hasCycle()); // In ra kết quả kiểm tra chu trình
+        System.out.println("Do thi co chu trinh le: " + graph.hasOddCycle()); // In ra kết quả kiểm tra chu trình độ dài lẻ
+        System.out.println("Do thi co chu trinh Euler: " + graph.hasEulerianCycle()); // In ra khả năng tồn tại chu trình Euler
+        System.out.println("Do thi co chu trinh Hamilton: " + graph.hasHamiltonianCycle()); // In ra khả năng tồn tại chu trình Hamilton
+        System.out.println("Do thi co chu trinh am: " + graph.hasNegativeCycle()); // In ra kết quả phát hiện chu trình âm
 
         List<City> bfsOrder = graph.breadthFirstTraversal(hanoi); // Thực hiện BFS từ Hà Nội
         System.out.println("Thu tu BFS: " + bfsOrder); // In ra thứ tự duyệt BFS

--- a/src/graph/RoadGraph.java
+++ b/src/graph/RoadGraph.java
@@ -99,6 +99,152 @@ public class RoadGraph { // Lớp RoadGraph quản lý đồ thị đường đi
         return false; // Không phát hiện chu trình từ nhánh hiện tại
     }
 
+    public boolean hasOddCycle() { // Kiểm tra đồ thị có chu trình độ dài lẻ hay không
+        int n = cities.size(); // Lấy số lượng thành phố trong đồ thị
+        if (n == 0) { // Nếu không có thành phố nào
+            return false; // Đồ thị rỗng nên không có chu trình
+        }
+        int[] color = new int[n]; // Mảng lưu màu của từng thành phố để kiểm tra tính hai phía
+        Arrays.fill(color, -1); // Gán tất cả giá trị ban đầu là -1 để biểu thị chưa tô màu
+        for (int startId = 0; startId < n; startId++) { // Duyệt qua từng thành phố làm điểm bắt đầu
+            if (color[startId] != -1) { // Nếu thành phố đã được tô màu trước đó
+                continue; // Bỏ qua vì đã thuộc một thành phần liên thông đã xét
+            }
+            if (detectOddCycleFrom(startId, color)) { // Gọi hàm phụ sử dụng BFS để tìm chu trình lẻ
+                return true; // Nếu phát hiện chu trình lẻ thì kết luận tồn tại
+            }
+        }
+        return false; // Sau khi duyệt hết các thành phần mà không tìm thấy thì trả về false
+    }
+
+    private boolean detectOddCycleFrom(int startId, int[] color) { // Hàm phụ duyệt BFS để phát hiện chu trình lẻ
+        Queue<Integer> queue = new ArrayDeque<>(); // Hàng đợi phục vụ cho quá trình tô màu xen kẽ
+        color[startId] = 0; // Tô màu ban đầu cho thành phố xuất phát
+        queue.add(startId); // Đưa thành phố xuất phát vào hàng đợi
+        while (!queue.isEmpty()) { // Lặp cho đến khi xử lý xong mọi thành phố có thể
+            int currentId = queue.remove(); // Lấy thành phố ở đầu hàng đợi ra xử lý
+            for (int neighborId : adjacencyList.get(currentId)) { // Duyệt qua các thành phố kề với thành phố hiện tại
+                if (color[neighborId] == -1) { // Nếu thành phố kề chưa được tô màu
+                    color[neighborId] = 1 - color[currentId]; // Tô màu đối lập với thành phố hiện tại
+                    queue.add(neighborId); // Thêm thành phố kề vào hàng đợi để tiếp tục xử lý
+                } else if (color[neighborId] == color[currentId]) { // Nếu gặp thành phố kề đã tô cùng màu
+                    return true; // Phát hiện chu trình lẻ vì đồ thị không thể tô hai màu
+                }
+            }
+        }
+        return false; // Không phát hiện chu trình lẻ trong thành phần liên thông hiện tại
+    }
+
+    public boolean hasEulerianCycle() { // Kiểm tra đồ thị có chu trình Euler hay không
+        if (cities.isEmpty()) { // Nếu chưa có thành phố nào trong đồ thị
+            return false; // Không có chu trình Euler trong đồ thị rỗng
+        }
+        int startId = -1; // Biến lưu chỉ số thành phố bắt đầu duyệt liên thông
+        for (int cityId = 0; cityId < cities.size(); cityId++) { // Duyệt qua các thành phố để tìm thành phố có cạnh
+            if (!adjacencyList.get(cityId).isEmpty()) { // Nếu thành phố có ít nhất một cạnh kề
+                startId = cityId; // Ghi nhận thành phố đó làm điểm bắt đầu
+                break; // Thoát vòng lặp vì đã tìm được điểm phù hợp
+            }
+        }
+        if (startId == -1) { // Nếu không tìm thấy thành phố nào có cạnh kề
+            return false; // Không thể tạo chu trình Euler vì đồ thị không có cạnh
+        }
+        Set<Integer> visited = new HashSet<>(); // Tập lưu các thành phố đã được duyệt
+        Queue<Integer> queue = new ArrayDeque<>(); // Hàng đợi dùng để kiểm tra tính liên thông của các cạnh
+        visited.add(startId); // Đánh dấu thành phố bắt đầu đã được duyệt
+        queue.add(startId); // Thêm thành phố bắt đầu vào hàng đợi
+        while (!queue.isEmpty()) { // Lặp cho đến khi xử lý hết các thành phố liên quan
+            int currentId = queue.remove(); // Lấy thành phố ở đầu hàng đợi ra xử lý
+            for (int neighborId : adjacencyList.get(currentId)) { // Duyệt qua từng thành phố kề
+                if (!visited.contains(neighborId)) { // Nếu thành phố kề chưa được duyệt
+                    visited.add(neighborId); // Đánh dấu thành phố kề đã được ghé
+                    queue.add(neighborId); // Thêm thành phố kề vào hàng đợi để kiểm tra tiếp
+                }
+            }
+        }
+        for (int cityId = 0; cityId < cities.size(); cityId++) { // Sau khi kiểm tra liên thông, duyệt lại từng thành phố
+            if (!adjacencyList.get(cityId).isEmpty() && !visited.contains(cityId)) { // Nếu thành phố có cạnh nhưng chưa được ghé
+                return false; // Không liên thông theo cạnh nên không thể có chu trình Euler
+            }
+        }
+        for (List<Integer> neighbors : adjacencyList) { // Duyệt qua từng danh sách kề để kiểm tra bậc đỉnh
+            if (neighbors.size() % 2 != 0) { // Nếu phát hiện thành phố có bậc lẻ
+                return false; // Chu trình Euler không tồn tại khi có đỉnh bậc lẻ
+            }
+        }
+        return true; // Nếu liên thông và mọi đỉnh có bậc chẵn thì tồn tại chu trình Euler
+    }
+
+    public boolean hasHamiltonianCycle() { // Kiểm tra đồ thị có chu trình Hamilton hay không
+        int n = cities.size(); // Lấy số lượng thành phố hiện có
+        if (n < 3) { // Nếu số thành phố ít hơn 3
+            return false; // Chu trình Hamilton cần ít nhất ba thành phố để tạo vòng khép kín
+        }
+        boolean[] visited = new boolean[n]; // Mảng đánh dấu các thành phố đã nằm trên đường đi hiện tại
+        visited[0] = true; // Chọn thành phố đầu tiên làm điểm xuất phát và đánh dấu đã ghé
+        return searchHamiltonianCycle(0, 0, visited, 1); // Gọi hàm đệ quy để thử xây dựng chu trình Hamilton
+    }
+
+    private boolean searchHamiltonianCycle(int currentId, int startId, boolean[] visited, int visitedCount) { // Hàm đệ quy tìm chu trình Hamilton
+        if (visitedCount == cities.size()) { // Nếu đã ghé qua đủ số lượng thành phố
+            for (int neighborId : adjacencyList.get(currentId)) { // Kiểm tra các cạnh xuất phát từ thành phố hiện tại
+                if (neighborId == startId) { // Nếu có cạnh quay về điểm xuất phát
+                    return true; // Đã hình thành chu trình Hamilton khép kín
+                }
+            }
+            return false; // Không có cạnh quay về điểm xuất phát nên không tạo thành chu trình hoàn chỉnh
+        }
+        for (int neighborId : adjacencyList.get(currentId)) { // Duyệt qua từng thành phố kề với thành phố hiện tại
+            if (!visited[neighborId]) { // Chỉ xét các thành phố chưa được ghé
+                visited[neighborId] = true; // Đánh dấu thành phố này đã được đưa vào đường đi
+                if (searchHamiltonianCycle(neighborId, startId, visited, visitedCount + 1)) { // Gọi đệ quy để tiếp tục mở rộng đường đi
+                    return true; // Nếu nhánh con tìm được chu trình Hamilton thì truyền kết quả lên
+                }
+                visited[neighborId] = false; // Quay lui và bỏ đánh dấu để thử nhánh khác
+            }
+        }
+        return false; // Thử hết các hàng xóm mà không tìm được chu trình thì trả về false
+    }
+
+    public boolean hasNegativeCycle() { // Kiểm tra đồ thị có chu trình âm hay không
+        int n = cities.size(); // Lấy số lượng thành phố trong đồ thị
+        if (n == 0) { // Nếu không có thành phố nào
+            return false; // Đồ thị rỗng nên không thể chứa chu trình âm
+        }
+        int[] distance = new int[n]; // Mảng lưu giá trị tạm thời để thư giãn các cạnh
+        Arrays.fill(distance, 0); // Khởi tạo tất cả khoảng cách bằng 0 giống như thêm một siêu nguồn
+        for (int iteration = 0; iteration < n - 1; iteration++) { // Thực hiện n-1 lần thư giãn cạnh theo Bellman-Ford
+            boolean updated = false; // Cờ đánh dấu xem lần lặp hiện tại có cập nhật hay không
+            for (int fromId = 0; fromId < n; fromId++) { // Duyệt qua từng thành phố làm đầu mối cạnh
+                List<Integer> neighbors = adjacencyList.get(fromId); // Lấy danh sách thành phố kề với fromId
+                List<Integer> weights = weightList.get(fromId); // Lấy danh sách trọng số tương ứng với các cạnh
+                for (int edgeIndex = 0; edgeIndex < neighbors.size(); edgeIndex++) { // Duyệt qua từng cạnh cụ thể
+                    int toId = neighbors.get(edgeIndex); // Lấy mã thành phố đích của cạnh
+                    int weight = weights.get(edgeIndex); // Lấy trọng số của cạnh đang xét
+                    if (distance[fromId] + weight < distance[toId]) { // Nếu khoảng cách mới nhỏ hơn giá trị hiện tại
+                        distance[toId] = distance[fromId] + weight; // Cập nhật khoảng cách tốt hơn cho thành phố đích
+                        updated = true; // Đánh dấu có cập nhật trong vòng lặp này
+                    }
+                }
+            }
+            if (!updated) { // Nếu không có cập nhật nào trong toàn bộ vòng lặp
+                break; // Dừng sớm vì không thể cải thiện thêm
+            }
+        }
+        for (int fromId = 0; fromId < n; fromId++) { // Sau khi thư giãn n-1 lần, kiểm tra thêm lần nữa
+            List<Integer> neighbors = adjacencyList.get(fromId); // Lấy danh sách thành phố kề của fromId
+            List<Integer> weights = weightList.get(fromId); // Lấy trọng số tương ứng
+            for (int edgeIndex = 0; edgeIndex < neighbors.size(); edgeIndex++) { // Duyệt qua từng cạnh
+                int toId = neighbors.get(edgeIndex); // Lấy mã thành phố đích của cạnh
+                int weight = weights.get(edgeIndex); // Lấy trọng số tương ứng của cạnh
+                if (distance[fromId] + weight < distance[toId]) { // Nếu vẫn có thể giảm khoảng cách
+                    return true; // Tồn tại chu trình âm nên trả về true
+                }
+            }
+        }
+        return false; // Không phát hiện chu trình âm nào trong đồ thị
+    }
+
     public List<City> breadthFirstTraversal(City start) { // Thuật toán duyệt BFS bắt đầu từ một thành phố
         List<City> order = new ArrayList<>(); // Danh sách lưu thứ tự các thành phố được duyệt
         Set<Integer> visited = new HashSet<>(); // Tập đánh dấu các thành phố đã ghé qua

--- a/src/graph/RoadGraph.java
+++ b/src/graph/RoadGraph.java
@@ -1,0 +1,313 @@
+package graph; // Khai báo package cho lớp RoadGraph
+
+import java.util.ArrayDeque; // Sử dụng ArrayDeque cho hàng đợi duyệt BFS và kiểm tra liên thông
+import java.util.ArrayList; // Sử dụng ArrayList cho các danh sách động lưu thành phố và cạnh
+import java.util.Arrays; // Sử dụng Arrays để gán nhanh giá trị cho mảng
+import java.util.Collections; // Sử dụng Collections để đảo danh sách khi dựng đường đi
+import java.util.Deque; // Sử dụng Deque cho ngăn xếp trong DFS
+import java.util.HashSet; // Sử dụng HashSet để đánh dấu các đỉnh đã thăm
+import java.util.LinkedList; // Sử dụng LinkedList để dựng lại đường đi không trọng số
+import java.util.List; // Sử dụng List làm kiểu danh sách tổng quát
+import java.util.PriorityQueue; // Sử dụng PriorityQueue cho thuật toán Dijkstra
+import java.util.Queue; // Sử dụng Queue cho thuật toán BFS
+import java.util.Set; // Sử dụng Set để lưu các đỉnh đã duyệt
+
+public class RoadGraph { // Lớp RoadGraph quản lý đồ thị đường đi giữa các thành phố
+    private static final int INF = 1_000_000_000; // Giá trị lớn dùng làm vô cực trong các thuật toán đường đi
+    private final List<City> cities; // Danh sách các thành phố hiện có
+    private final List<List<Integer>> adjacencyList; // Danh sách kề lưu cạnh giữa các thành phố theo chỉ số
+    private final List<List<Integer>> weightList; // Danh sách song song lưu trọng số từng cạnh
+
+    public RoadGraph() { // Hàm tạo mặc định của đồ thị
+        this.cities = new ArrayList<>(); // Khởi tạo danh sách thành phố rỗng
+        this.adjacencyList = new ArrayList<>(); // Khởi tạo danh sách kề rỗng
+        this.weightList = new ArrayList<>(); // Khởi tạo danh sách trọng số rỗng tương ứng
+    }
+
+    public City addCity(String name) { // Thêm một thành phố mới vào đồ thị
+        City newCity = new City(cities.size(), name); // Tạo đối tượng City với mã số tăng dần
+        cities.add(newCity); // Lưu thành phố mới vào danh sách cities
+        adjacencyList.add(new ArrayList<>()); // Tạo danh sách kề rỗng tương ứng cho thành phố mới
+        weightList.add(new ArrayList<>()); // Tạo danh sách trọng số rỗng cho thành phố mới
+        return newCity; // Trả về thành phố vừa tạo để người dùng tiện sử dụng
+    }
+
+    public void addRoad(City from, City to) { // Thêm đường đi hai chiều không trọng số rõ ràng
+        addRoad(from, to, 1); // Gọi tới phương thức thêm đường có trọng số với giá trị mặc định bằng 1
+    }
+
+    public void addRoad(City from, City to, int distance) { // Thêm đường đi hai chiều với trọng số cụ thể
+        int fromId = from.getId(); // Lấy mã số của thành phố nguồn
+        int toId = to.getId(); // Lấy mã số của thành phố đích
+        adjacencyList.get(fromId).add(toId); // Thêm chỉ số thành phố đích vào danh sách kề của thành phố nguồn
+        weightList.get(fromId).add(distance); // Thêm trọng số cạnh tương ứng vào danh sách trọng số của thành phố nguồn
+        adjacencyList.get(toId).add(fromId); // Thêm chiều ngược lại vì đồ thị vô hướng
+        weightList.get(toId).add(distance); // Thêm trọng số cho chiều ngược lại
+    }
+
+    public List<City> getNeighbors(City city) { // Lấy danh sách thành phố kề với một thành phố đã cho
+        List<City> neighbors = new ArrayList<>(); // Tạo danh sách kết quả rỗng ban đầu
+        for (int neighborId : adjacencyList.get(city.getId())) { // Duyệt qua từng chỉ số thành phố kề
+            neighbors.add(cities.get(neighborId)); // Tra chỉ số sang đối tượng City và thêm vào kết quả
+        }
+        return neighbors; // Trả về danh sách thành phố kề
+    }
+
+    public boolean isConnected() { // Kiểm tra đồ thị có liên thông hay không
+        if (cities.isEmpty()) { // Nếu không có thành phố nào trong đồ thị
+            return true; // Trả về true vì đồ thị rỗng được xem là liên thông
+        }
+        Set<Integer> visited = new HashSet<>(); // Tập đánh dấu các thành phố đã ghé qua
+        Queue<Integer> queue = new ArrayDeque<>(); // Hàng đợi phục vụ cho BFS kiểm tra liên thông
+        visited.add(0); // Đánh dấu thành phố đầu tiên trong danh sách
+        queue.add(0); // Đưa thành phố đầu tiên vào hàng đợi
+        while (!queue.isEmpty()) { // Lặp cho đến khi không còn thành phố trong hàng đợi
+            int currentId = queue.remove(); // Lấy mã thành phố ở đầu hàng đợi ra xử lý
+            for (int neighborId : adjacencyList.get(currentId)) { // Duyệt qua từng thành phố kề với thành phố hiện tại
+                if (!visited.contains(neighborId)) { // Chỉ xử lý nếu thành phố kề chưa được ghé
+                    visited.add(neighborId); // Đánh dấu đã ghé để không xử lý lại
+                    queue.add(neighborId); // Thêm thành phố kề vào hàng đợi để duyệt tiếp
+                }
+            }
+        }
+        return visited.size() == cities.size(); // Đồ thị liên thông khi số thành phố đã ghé bằng tổng số thành phố
+    }
+
+    public boolean hasCycle() { // Kiểm tra đồ thị vô hướng có chu trình hay không
+        Set<Integer> visited = new HashSet<>(); // Tập các thành phố đã duyệt
+        for (int cityId = 0; cityId < cities.size(); cityId++) { // Duyệt qua từng thành phố theo chỉ số
+            if (!visited.contains(cityId)) { // Nếu thành phố chưa được duyệt
+                if (detectCycleFrom(cityId, -1, visited)) { // Gọi DFS và trả về true nếu phát hiện chu trình
+                    return true; // Kết luận tồn tại chu trình
+                }
+            }
+        }
+        return false; // Trả về false nếu duyệt xong mà không tìm thấy chu trình nào
+    }
+
+    private boolean detectCycleFrom(int currentId, int parentId, Set<Integer> visited) { // Hàm DFS phụ để phát hiện chu trình
+        visited.add(currentId); // Đánh dấu thành phố hiện tại đã được duyệt
+        for (int neighborId : adjacencyList.get(currentId)) { // Duyệt qua các thành phố kề với thành phố hiện tại
+            if (!visited.contains(neighborId)) { // Nếu gặp thành phố chưa duyệt
+                if (detectCycleFrom(neighborId, currentId, visited)) { // Đệ quy kiểm tra các nhánh sâu hơn
+                    return true; // Nếu nhánh con phát hiện chu trình thì trả về true
+                }
+            } else if (neighborId != parentId) { // Nếu gặp lại thành phố đã duyệt và không phải cha trực tiếp
+                return true; // Phát hiện chu trình vì có cạnh ngược lại ngoài cha
+            }
+        }
+        return false; // Không phát hiện chu trình từ nhánh hiện tại
+    }
+
+    public List<City> breadthFirstTraversal(City start) { // Thuật toán duyệt BFS bắt đầu từ một thành phố
+        List<City> order = new ArrayList<>(); // Danh sách lưu thứ tự các thành phố được duyệt
+        Set<Integer> visited = new HashSet<>(); // Tập đánh dấu các thành phố đã ghé qua
+        Queue<Integer> queue = new ArrayDeque<>(); // Hàng đợi phục vụ cho BFS
+        visited.add(start.getId()); // Đánh dấu thành phố bắt đầu
+        queue.add(start.getId()); // Đưa thành phố bắt đầu vào hàng đợi
+        while (!queue.isEmpty()) { // Lặp cho đến khi không còn thành phố trong hàng đợi
+            int currentId = queue.remove(); // Lấy mã thành phố ở đầu hàng đợi ra xử lý
+            City currentCity = cities.get(currentId); // Lấy đối tượng City tương ứng với mã vừa lấy
+            order.add(currentCity); // Ghi nhận thành phố vào kết quả
+            for (int neighborId : adjacencyList.get(currentId)) { // Duyệt qua từng thành phố kề với thành phố hiện tại
+                if (!visited.contains(neighborId)) { // Chỉ xử lý nếu thành phố kề chưa được ghé
+                    visited.add(neighborId); // Đánh dấu đã ghé để không xử lý lại
+                    queue.add(neighborId); // Thêm thành phố kề vào hàng đợi để duyệt tiếp
+                }
+            }
+        }
+        return order; // Hoàn trả thứ tự duyệt BFS để người học dễ quan sát
+    }
+
+    public List<City> depthFirstTraversal(City start) { // Thuật toán duyệt DFS dùng ngăn xếp
+        List<City> order = new ArrayList<>(); // Danh sách lưu thứ tự các thành phố đã duyệt
+        Set<Integer> visited = new HashSet<>(); // Tập đánh dấu các thành phố đã ghé
+        Deque<Integer> stack = new ArrayDeque<>(); // Ngăn xếp dùng để mô phỏng DFS
+        stack.push(start.getId()); // Đưa thành phố bắt đầu vào ngăn xếp
+        while (!stack.isEmpty()) { // Lặp cho đến khi không còn thành phố trong ngăn xếp
+            int currentId = stack.pop(); // Lấy mã thành phố ở đỉnh ngăn xếp ra xử lý
+            if (visited.contains(currentId)) { // Bỏ qua nếu thành phố đã được duyệt trước đó
+                continue; // Chuyển sang bước tiếp theo
+            }
+            visited.add(currentId); // Đánh dấu thành phố hiện tại
+            City currentCity = cities.get(currentId); // Lấy đối tượng City tương ứng
+            order.add(currentCity); // Ghi nhận thành phố vào kết quả
+            for (int neighborId : adjacencyList.get(currentId)) { // Duyệt qua từng thành phố kề
+                if (!visited.contains(neighborId)) { // Chỉ thêm vào ngăn xếp nếu chưa duyệt
+                    stack.push(neighborId); // Đưa thành phố kề vào ngăn xếp để xử lý sau
+                }
+            }
+        }
+        return order; // Trả về thứ tự duyệt DFS để tiện đối chiếu với BFS
+    }
+
+    public List<City> shortestPath(City start, City end) { // Tìm đường đi ngắn nhất bằng BFS trên đồ thị vô hướng không trọng số
+        int startId = start.getId(); // Lấy mã của thành phố bắt đầu
+        int endId = end.getId(); // Lấy mã của thành phố đích
+        int[] previous = new int[cities.size()]; // Mảng lưu lại đỉnh trước đó trên đường đi
+        for (int i = 0; i < previous.length; i++) { // Khởi tạo giá trị ban đầu cho mảng previous
+            previous[i] = -1; // Gán -1 để thể hiện chưa có đỉnh trước đó
+        }
+        Queue<Integer> queue = new LinkedList<>(); // Hàng đợi sử dụng trong BFS
+        Set<Integer> visited = new HashSet<>(); // Tập đánh dấu các thành phố đã thăm
+        visited.add(startId); // Đánh dấu thành phố bắt đầu
+        queue.add(startId); // Thêm thành phố bắt đầu vào hàng đợi
+        while (!queue.isEmpty()) { // Lặp cho đến khi hàng đợi rỗng
+            int currentId = queue.remove(); // Lấy một thành phố từ hàng đợi ra
+            if (currentId == endId) { // Nếu đã đến thành phố đích
+                break; // Thoát vòng lặp vì đã tìm thấy đường đi
+            }
+            for (int neighborId : adjacencyList.get(currentId)) { // Duyệt qua các thành phố kề
+                if (!visited.contains(neighborId)) { // Chỉ xử lý khi thành phố kề chưa ghé
+                    visited.add(neighborId); // Đánh dấu đã ghé để tránh lặp
+                    previous[neighborId] = currentId; // Ghi nhận đỉnh trước đó của thành phố kề
+                    queue.add(neighborId); // Thêm thành phố kề vào hàng đợi để tiếp tục BFS
+                }
+            }
+        }
+        if (previous[endId] == -1 && startId != endId) { // Nếu không có đường đi và điểm đầu khác điểm cuối
+            return Collections.emptyList(); // Trả về danh sách rỗng biểu thị không tìm thấy đường đi
+        }
+        List<City> path = new ArrayList<>(); // Danh sách lưu đường đi ngắn nhất từ cuối lên đầu
+        for (int currentId = endId; currentId != -1; currentId = previous[currentId]) { // Lần ngược từ đích về nguồn
+            path.add(cities.get(currentId)); // Thêm thành phố hiện tại vào danh sách đường đi
+        }
+        Collections.reverse(path); // Đảo ngược danh sách để có thứ tự từ nguồn đến đích
+        return path; // Trả về đường đi ngắn nhất để người học quan sát
+    }
+
+    public List<City> shortestPathDijkstra(City start, City end) { // Tìm đường đi ngắn nhất có trọng số bằng thuật toán Dijkstra
+        int n = cities.size(); // Lấy số lượng thành phố trong đồ thị
+        int[] distance = new int[n]; // Mảng lưu khoảng cách ngắn nhất tạm thời tới từng thành phố
+        int[] previous = new int[n]; // Mảng lưu lại đỉnh trước đó trên đường đi tốt nhất hiện tại
+        Arrays.fill(distance, INF); // Khởi tạo tất cả khoảng cách bằng vô cực
+        Arrays.fill(previous, -1); // Khởi tạo đỉnh trước đó bằng -1 thể hiện chưa xác định
+        int startId = start.getId(); // Lấy mã của thành phố bắt đầu
+        int endId = end.getId(); // Lấy mã của thành phố đích
+        distance[startId] = 0; // Khoảng cách tới chính nó bằng 0
+        PriorityQueue<int[]> queue = new PriorityQueue<>((a, b) -> Integer.compare(a[1], b[1])); // Hàng đợi ưu tiên chọn đỉnh có khoảng cách nhỏ nhất
+        queue.add(new int[]{startId, 0}); // Đưa thành phố bắt đầu cùng khoảng cách 0 vào hàng đợi
+        while (!queue.isEmpty()) { // Lặp cho đến khi không còn đỉnh nào cần xử lý
+            int[] entry = queue.remove(); // Lấy phần tử có khoảng cách nhỏ nhất ra khỏi hàng đợi
+            int currentId = entry[0]; // Tách mã thành phố đang xét
+            int currentDistance = entry[1]; // Lấy khoảng cách tương ứng của thành phố đó
+            if (currentDistance > distance[currentId]) { // Nếu phần tử đang xét không còn tối ưu
+                continue; // Bỏ qua để tránh xử lý thừa
+            }
+            if (currentId == endId) { // Nếu đã tới thành phố đích
+                break; // Thoát vòng lặp vì đã có khoảng cách tốt nhất
+            }
+            List<Integer> neighbors = adjacencyList.get(currentId); // Lấy danh sách hàng xóm của thành phố hiện tại
+            List<Integer> weights = weightList.get(currentId); // Lấy danh sách trọng số tương ứng với từng hàng xóm
+            for (int i = 0; i < neighbors.size(); i++) { // Duyệt qua tất cả hàng xóm
+                int neighborId = neighbors.get(i); // Lấy mã hàng xóm
+                int weight = weights.get(i); // Lấy trọng số cạnh tới hàng xóm đó
+                int newDistance = currentDistance + weight; // Tính khoảng cách mới nếu đi qua thành phố hiện tại
+                if (newDistance < distance[neighborId]) { // Nếu khoảng cách mới tốt hơn khoảng cách cũ
+                    distance[neighborId] = newDistance; // Cập nhật khoảng cách tốt hơn
+                    previous[neighborId] = currentId; // Lưu lại đỉnh trước đó để dựng đường đi
+                    queue.add(new int[]{neighborId, newDistance}); // Đưa hàng xóm vào hàng đợi để xét tiếp
+                }
+            }
+        }
+        if (distance[endId] == INF) { // Nếu không tìm được đường đi tới thành phố đích
+            return Collections.emptyList(); // Trả về danh sách rỗng để biểu thị thất bại
+        }
+        List<City> path = new ArrayList<>(); // Danh sách lưu đường đi tìm được
+        for (int currentId = endId; currentId != -1; currentId = previous[currentId]) { // Lần ngược từ đích về nguồn
+            path.add(cities.get(currentId)); // Thêm thành phố hiện tại vào danh sách đường đi
+        }
+        Collections.reverse(path); // Đảo ngược để có đường đi theo chiều từ nguồn tới đích
+        return path; // Trả về đường đi có trọng số ngắn nhất
+    }
+
+    public int[][] floydWarshall() { // Thuật toán Floyd-Warshall để tìm đường đi ngắn nhất giữa mọi cặp thành phố
+        int n = cities.size(); // Lấy số lượng thành phố trong đồ thị
+        int[][] dist = new int[n][n]; // Ma trận lưu khoảng cách giữa mọi cặp thành phố
+        for (int i = 0; i < n; i++) { // Duyệt qua từng hàng của ma trận
+            for (int j = 0; j < n; j++) { // Duyệt qua từng cột của ma trận
+                if (i == j) { // Nếu đang xét phần tử trên đường chéo chính
+                    dist[i][j] = 0; // Khoảng cách từ một thành phố tới chính nó bằng 0
+                } else { // Ngược lại là hai thành phố khác nhau
+                    dist[i][j] = INF; // Gán khoảng cách ban đầu bằng vô cực
+                }
+            }
+        }
+        for (int i = 0; i < n; i++) { // Duyệt qua từng thành phố để đặt khoảng cách trực tiếp
+            List<Integer> neighbors = adjacencyList.get(i); // Lấy danh sách hàng xóm của thành phố i
+            List<Integer> weights = weightList.get(i); // Lấy trọng số tương ứng với từng hàng xóm
+            for (int j = 0; j < neighbors.size(); j++) { // Duyệt qua các hàng xóm
+                int neighborId = neighbors.get(j); // Lấy mã hàng xóm
+                int weight = weights.get(j); // Lấy trọng số cạnh
+                dist[i][neighborId] = Math.min(dist[i][neighborId], weight); // Cập nhật khoảng cách trực tiếp nhỏ nhất
+            }
+        }
+        for (int k = 0; k < n; k++) { // Duyệt qua từng thành phố làm trung gian
+            for (int i = 0; i < n; i++) { // Duyệt qua thành phố nguồn
+                for (int j = 0; j < n; j++) { // Duyệt qua thành phố đích
+                    if (dist[i][k] == INF || dist[k][j] == INF) { // Bỏ qua nếu không có đường đi qua trung gian
+                        continue; // Tiếp tục sang cặp khác
+                    }
+                    int newDistance = dist[i][k] + dist[k][j]; // Tính khoảng cách thông qua trung gian k
+                    if (newDistance < dist[i][j]) { // Nếu khoảng cách mới nhỏ hơn khoảng cách hiện tại
+                        dist[i][j] = newDistance; // Cập nhật khoảng cách tốt hơn cho cặp (i, j)
+                    }
+                }
+            }
+        }
+        return dist; // Trả về ma trận khoảng cách giữa mọi cặp thành phố
+    }
+
+    public int[] bellmanFord(City start) { // Thuật toán Bellman-Ford tìm đường đi ngắn nhất từ một nguồn
+        int n = cities.size(); // Lấy số lượng thành phố trong đồ thị
+        int[] distance = new int[n]; // Mảng lưu khoảng cách tốt nhất tới từng thành phố
+        Arrays.fill(distance, INF); // Khởi tạo khoảng cách bằng vô cực
+        int startId = start.getId(); // Lấy mã số thành phố nguồn
+        distance[startId] = 0; // Khoảng cách từ nguồn tới chính nó bằng 0
+        for (int iteration = 0; iteration < n - 1; iteration++) { // Lặp n-1 lần để thư giãn các cạnh
+            boolean updated = false; // Cờ đánh dấu có cập nhật khoảng cách trong vòng lặp hay không
+            for (int fromId = 0; fromId < n; fromId++) { // Duyệt qua từng thành phố làm điểm xuất phát
+                if (distance[fromId] == INF) { // Nếu chưa thể đi tới thành phố này
+                    continue; // Bỏ qua vì không thể thư giãn cạnh xuất phát từ đây
+                }
+                List<Integer> neighbors = adjacencyList.get(fromId); // Lấy danh sách hàng xóm của fromId
+                List<Integer> weights = weightList.get(fromId); // Lấy trọng số tương ứng
+                for (int edgeIndex = 0; edgeIndex < neighbors.size(); edgeIndex++) { // Duyệt qua từng cạnh xuất phát từ fromId
+                    int toId = neighbors.get(edgeIndex); // Lấy mã thành phố đích của cạnh
+                    int weight = weights.get(edgeIndex); // Lấy trọng số của cạnh đang xét
+                    int newDistance = distance[fromId] + weight; // Tính khoảng cách mới qua cạnh này
+                    if (newDistance < distance[toId]) { // Nếu khoảng cách mới tốt hơn
+                        distance[toId] = newDistance; // Cập nhật khoảng cách tốt hơn cho thành phố đích
+                        updated = true; // Đánh dấu đã có cập nhật trong vòng lặp
+                    }
+                }
+            }
+            if (!updated) { // Nếu không có cập nhật nào trong vòng lặp
+                break; // Có thể dừng sớm vì khoảng cách đã tối ưu
+            }
+        }
+        for (int fromId = 0; fromId < n; fromId++) { // Kiểm tra sự tồn tại của chu trình âm
+            if (distance[fromId] == INF) { // Nếu không thể đi tới thành phố này thì bỏ qua
+                continue; // Tiếp tục sang thành phố khác
+            }
+            List<Integer> neighbors = adjacencyList.get(fromId); // Lấy danh sách hàng xóm của fromId
+            List<Integer> weights = weightList.get(fromId); // Lấy trọng số tương ứng
+            for (int edgeIndex = 0; edgeIndex < neighbors.size(); edgeIndex++) { // Duyệt qua các cạnh
+                int toId = neighbors.get(edgeIndex); // Lấy mã thành phố đích
+                int weight = weights.get(edgeIndex); // Lấy trọng số cạnh
+                if (distance[fromId] + weight < distance[toId]) { // Nếu vẫn có thể giảm khoảng cách
+                    throw new IllegalStateException("Do thi co chu trinh am"); // Ném ngoại lệ báo hiệu tồn tại chu trình âm
+                }
+            }
+        }
+        return distance; // Trả về mảng khoảng cách cuối cùng từ nguồn tới mọi thành phố
+    }
+
+    public int getInfinityValue() { // Trả về giá trị vô cực để tiện in kết quả bên ngoài
+        return INF; // Hoàn trả hằng số INF đã khai báo trong lớp
+    }
+
+    public List<City> getCities() { // Trả về danh sách toàn bộ thành phố trong đồ thị
+        return new ArrayList<>(cities); // Tạo bản sao để tránh bị sửa từ bên ngoài
+    }
+}


### PR DESCRIPTION
## Summary
- extend RoadGraph with weighted edges plus connectivity, cycle detection, Dijkstra, Floyd-Warshall, and Bellman-Ford methods for the city roadmap example, keeping Vietnamese comments on each line
- update GraphDemo to build weighted roads and print the new traversal, shortest path, and distance analyses for students to observe

## Testing
- javac src/graph/*.java

------
https://chatgpt.com/codex/tasks/task_e_68eeeed07894832c83c9b0e48efa95c8